### PR TITLE
small docs issue + metadata if there is none.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,7 @@ The easiest way to install sevenbridges-python is by using pip.
 Get the Code
 ============
 
-sevenbridges-python is actively developed on GitHub, where the code is always available.
+sevenbridges-python is actively developed on GitHub, where the `code <https://github.com/sbg/sevenbridges-python>`_ is always available.
 
 The easiest way to obtain the source is to clone the public repository
 ::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -492,6 +492,12 @@ Examples
     my_file['sample_id'] = 'my-sample'
     my_file['library'] = 'my-library'
     
+    # Add metadata (if you are starting with a file without metadata)
+    my_file = my_files[0]
+    my_file.metadata = {'sample_id' : 'my-sample',
+                        'library' : 'my-library'
+                      }
+
     # Save modifications
     my_file.save()
     


### PR DESCRIPTION
We weren't able to set metadata following the quick-start for files that had none. This small work-around solved the problem. 