### PR TITLE
Remaining Live and Autowait

### DIFF
--- a/sevenbridges/api.py
+++ b/sevenbridges/api.py
@@ -31,7 +31,7 @@ class Api(HttpClient):
 
     def __init__(self, url=None, token=None, oauth_token=None, config=None,
                  timeout=None, retry=5, download_max_workers=16,
-                 upload_max_workers=16):
+                 upload_max_workers=16, autowait = False):
         """
         Initializes api object. If url and token are not supplied,
         the check for the .sbgrc configuration file will occur, checking if the
@@ -47,11 +47,13 @@ class Api(HttpClient):
         :param retry: Number of retries.
         :param download_max_workers: Max number of threads for download.
         :param upload_max_workers: Max number of threads for upload.
+        :param autowait: automatically wait to stay under rate limit
         :return: Api object instance.
         """
         super(Api, self).__init__(url=url, token=token,
                                   oauth_token=oauth_token,
-                                  config=config, retry=retry, timeout=timeout)
+                                  config=config, retry=retry, timeout=timeout,
+                                  autowait=autowait)
 
         self.download_pool = ThreadPoolExecutor(
             max_workers=download_max_workers

--- a/sevenbridges/http/client.py
+++ b/sevenbridges/http/client.py
@@ -76,17 +76,17 @@ class HttpClient(object):
 
     @property
     def limit(self):
-        self._rate_limit(self)
+        self._rate_limit()
         return int(self._limit) if self._limit else self._limit
 
     @property
     def remaining(self):
-        self._rate_limit(self)
+        self._rate_limit()
         return int(self._remaining) if self._remaining else self._remaining
 
     @property
     def reset_time(self):
-        self._rate_limit(self)
+        self._rate_limit()
         return dt.fromtimestamp(
             float(self._reset)
         ) if self._reset else self._reset

--- a/sevenbridges/http/client.py
+++ b/sevenbridges/http/client.py
@@ -1,6 +1,7 @@
 import json
 import platform
 from datetime import datetime as dt
+from time import sleep
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -27,7 +28,7 @@ class HttpClient(object):
     """
 
     def __init__(self, url=None, token=None, oauth_token=None, config=None,
-                 timeout=None, retry=5):
+                 timeout=None, retry=5, autowait = False):
 
         if config is not None:
             url = config.api_url
@@ -49,6 +50,7 @@ class HttpClient(object):
         self._remaining = None
         self._reset = None
         self._request_id = None
+        self._autowait = autowait
         self.headers = {
             'Content-Type': 'application/json',
             'User-Agent':
@@ -74,14 +76,17 @@ class HttpClient(object):
 
     @property
     def limit(self):
+        self._rate_limit(self)
         return int(self._limit) if self._limit else self._limit
 
     @property
     def remaining(self):
+        self._rate_limit(self)
         return int(self._remaining) if self._remaining else self._remaining
 
     @property
     def reset_time(self):
+        self._rate_limit(self)
         return dt.fromtimestamp(
             float(self._reset)
         ) if self._reset else self._reset
@@ -89,6 +94,9 @@ class HttpClient(object):
     @property
     def request_id(self):
         return self._request_id
+
+    def _rate_limit(self):
+        self._request('GET', url='rate_limit', append_base=True)
 
     @check_for_error
     def _request(self, verb, url, headers=None, params=None, data=None,
@@ -113,6 +121,12 @@ class HttpClient(object):
         headers = response.headers
         self._limit = headers.get('X-RateLimit-Limit', self._limit)
         self._remaining = headers.get('X-RateLimit-Remaining', self._remaining)
+
+        if self._autowait and self._remaining < 1:
+            sleep = int(self._remaining) - int(time.time())
+            if sleep > 0:
+                time.sleep(sleep + 5)
+
         self._reset = headers.get('X-RateLimit-Reset', self._reset)
         self._last_response_time = response.elapsed.total_seconds()
 


### PR DESCRIPTION
1. Added functionality to always pull the remaining time and amount live. Is necessary when having multiple clients using the same API key, the remaining from the last call isn't necessarily accurate.
2. Added feature to automatically sleep when remaining is low. Currently, the behavior is that the call results in an error. When this occurs inside of any kind of loop, like starting 100 separate tasks, the loop fails on a random index and attempting to restart the loop at the point of failure is challenging. Automatically sleeping allows the API to gracefully wait until the remaining is back up, without causing an error. 