### PR TITLE
Do not strip revision number from app ID string

### DIFF
--- a/sevenbridges/models/app.py
+++ b/sevenbridges/models/app.py
@@ -97,12 +97,6 @@ class App(Resource):
         :param api: Api instance.
         :return: App object.
         """
-        try:
-            id = id.rsplit('/', 1)[0]
-        except IndexError:
-            SbgError(message='Malformed app id %s, '
-                             'expecting owner/project/app/revision' % id)
-
         api = api if api else cls._API
         app = api.post(url=cls._URL['create_revision'].format(
             id=id, revision=revision), data=raw).json()


### PR DESCRIPTION
Attempting to strip the revision number from an app ID string which does not
contain a revision number will result in an invalid app ID.
Now `app.create_revision` should work with app ID's returned by `app.id`.

Fixes #37.