### PR TITLE
Resource objects contain original data used for their initialization

### DIFF
--- a/sevenbridges/meta/resource.py
+++ b/sevenbridges/meta/resource.py
@@ -45,6 +45,7 @@ class ResourceMeta(type):
                     urls = None
                 self._data = DataContainer(urls=urls, api=self._api)
                 self._dirty = {}
+                self.raw = kwargs
                 for k, v in kwargs.items():
                     if k in fields:
                         value = fields[k].validate(v)

--- a/sevenbridges/tests/test_tasks.py
+++ b/sevenbridges/tests/test_tasks.py
@@ -206,3 +206,17 @@ def test_get_execution_details(api, given, verifier):
 
     # verification
     verifier.task.execution_details_fetched(id=id)
+
+
+def test_raw_response(api, given, verifier):
+    # precondition
+    id = generator.uuid4()
+    given.task.task_exists(id=id)
+
+    # action
+    task = api.tasks.get(id=id)
+
+    # verification
+    verifier.task.task_fetched(id=id)
+    assert isinstance(task.raw, dict)
+    assert {'app', 'href', 'id', 'inputs'} <= set(task.raw.keys())


### PR DESCRIPTION
Useful in situations when direct access to raw response data for inspection
or manipulation purposes is desired -- when the abstractions that wrap
responses present an obstacle instead of being helpful.