### PR TITLE
Fix: handle `None` messages

### DIFF
--- a/sevenbridges/errors.py
+++ b/sevenbridges/errors.py
@@ -17,7 +17,7 @@ class SbgError(Exception):
         self.more_info = more_info
 
     def __str__(self):
-        return self.message
+        return str(self.message)
 
 
 class ResourceNotModified(SbgError):


### PR DESCRIPTION
When we evaluate `print(e)` where `e` is an instance of `SbgError` if `e.message` is `None` `print` and any other function that expects a `str` will error out. This ensures we get returned a `str` type from `__str__`

Thanks!